### PR TITLE
Backporting IdentityServer 4 support for optional client secret

### DIFF
--- a/source/Core/Constants.cs
+++ b/source/Core/Constants.cs
@@ -639,6 +639,7 @@ namespace IdentityServer3.Core
 
         public static class ParsedSecretTypes
         {
+            public const string NoSecret = "NoSecret";
             public const string SharedSecret = "SharedSecret";
             public const string X509Certificate = "X509Certificate";
             public const string JwtBearer = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";

--- a/source/Core/Models/Client.cs
+++ b/source/Core/Models/Client.cs
@@ -40,6 +40,22 @@ namespace IdentityServer3.Core.Models
         public List<Secret> ClientSecrets { get; set; }
 
         /// <summary>
+        /// If set to false, no client secret is needed to request tokens at the token endpoint (defaults to <c>true</c>)
+        /// </summary>
+        private bool _requireClientSecret = true;
+        public bool RequireClientSecret
+        {
+            get
+            {
+                return _requireClientSecret;
+            }
+            set
+            {
+                _requireClientSecret = value;
+            }
+        }
+
+        /// <summary>
         /// Client display name (used for logging and consent screen)
         /// </summary>
         public string ClientName { get; set; }

--- a/source/Core/Validation/PostBodySecretParser.cs
+++ b/source/Core/Validation/PostBodySecretParser.cs
@@ -42,49 +42,6 @@ namespace IdentityServer3.Core.Validation
             _options = options;
         }
 
-        ///// <summary>
-        ///// Tries to find a secret on the environment that can be used for authentication
-        ///// </summary>
-        ///// <param name="environment">The environment.</param>
-        ///// <returns>
-        ///// A parsed secret
-        ///// </returns>
-        //public async Task<ParsedSecret> ParseAsync(IDictionary<string, object> environment)
-        //{
-        //    Logger.Debug("Start parsing for secret in post body");
-
-        //    var context = new OwinContext(environment);
-        //    var body = await context.ReadRequestFormAsync();
-
-        //    if (body != null)
-        //    {
-        //        var id = body.Get("client_id");
-        //        var secret = body.Get("client_secret");
-
-        //        if (id.IsPresent() && secret.IsPresent())
-        //        {
-        //            if (id.Length > _options.InputLengthRestrictions.ClientId ||
-        //                secret.Length > _options.InputLengthRestrictions.ClientSecret)
-        //            {
-        //                Logger.Debug("Client ID or secret exceeds maximum lenght.");
-        //                return null;
-        //            }
-
-        //            var parsedSecret = new ParsedSecret
-        //            {
-        //                Id = id,
-        //                Credential = secret,
-        //                Type = Constants.ParsedSecretTypes.SharedSecret
-        //            };
-
-        //            return parsedSecret;
-        //        }
-        //    }
-
-        //    Logger.Debug("No secret in post body found");
-        //    return null;
-        //}
-
         /// <summary>
         /// Tries to find a secret on the environment that can be used for authentication
         /// </summary>

--- a/source/Core/Validation/PostBodySecretParser.cs
+++ b/source/Core/Validation/PostBodySecretParser.cs
@@ -65,7 +65,7 @@ namespace IdentityServer3.Core.Validation
                 {
                     if (id.Length > _options.InputLengthRestrictions.ClientId)
                     {
-                        Logger.Error("Client ID or secret exceeds maximum lenght.");
+                        Logger.Error("Client ID or secret exceeds maximum length.");
                         return null;
                     }
 

--- a/source/Core/Validation/SecretParser.cs
+++ b/source/Core/Validation/SecretParser.cs
@@ -20,20 +20,30 @@ namespace IdentityServer3.Core.Validation
         public async Task<ParsedSecret> ParseAsync(IDictionary<string, object> environment)
         {
             // see if a registered parser finds a secret on the request
-            ParsedSecret parsedSecret = null;
+            ParsedSecret bestSecret = null;
             foreach (var parser in _parsers)
             {
-                parsedSecret = await parser.ParseAsync(environment);
+                var parsedSecret = await parser.ParseAsync(environment);
                 if (parsedSecret != null)
                 {
-                    Logger.DebugFormat("Parser found secret: {0}", parser.GetType().Name);
-                    Logger.InfoFormat("Secret id found: {0}", parsedSecret.Id);
+                    Logger.DebugFormat("Parser found secret: {type}", parser.GetType().Name);
 
-                    return parsedSecret;
+                    bestSecret = parsedSecret;
+
+                    if (parsedSecret.Type != Constants.ParsedSecretTypes.NoSecret)
+                    {
+                        break;
+                    }
                 }
             }
 
-            Logger.InfoFormat("Parser found no secret");
+            if (bestSecret != null)
+            {
+                Logger.DebugFormat("Secret id found: {id}", bestSecret.Id);
+                return bestSecret;
+            }
+
+            Logger.DebugFormat("Parser found no secret");
             return null;
         }
     }

--- a/source/Tests/UnitTests/Validation/Secrets/FormPostCredentialParsing.cs
+++ b/source/Tests/UnitTests/Validation/Secrets/FormPostCredentialParsing.cs
@@ -119,7 +119,8 @@ namespace IdentityServer3.Tests.Validation.Secrets
 
             var secret = await _parser.ParseAsync(context.Environment);
 
-            secret.Should().BeNull();
+            secret.Should().NotBeNull();
+            secret.Type.Should().Be(Constants.ParsedSecretTypes.NoSecret);
         }
 
         [Fact]


### PR DESCRIPTION
@aks427 @eknowledger 

-- Note:  the Client gets a new property  (RequireClientSecret), this will require a database schema change.